### PR TITLE
Expose list peers and channels

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -51,7 +51,7 @@ interface Node {
 	[Throws=NodeError]
 	Invoice receive_variable_amount_payment([ByRef]string description, u32 expiry_secs);
 	PaymentInfo? payment_info([ByRef]PaymentHash payment_hash);
-	sequence<PublicKey> list_peers();
+	sequence<PeerDetails> list_peers();
 	sequence<ChannelDetails> list_channels();
 };
 
@@ -133,6 +133,11 @@ dictionary ChannelDetails {
     boolean is_usable;
     boolean is_public;
     u16? cltv_expiry_delta;
+};
+
+dictionary PeerDetails {
+    PublicKey node_id;
+    boolean is_connected;
 };
 
 [Custom]

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -52,6 +52,7 @@ interface Node {
 	Invoice receive_variable_amount_payment([ByRef]string description, u32 expiry_secs);
 	PaymentInfo? payment_info([ByRef]PaymentHash payment_hash);
 	sequence<PublicKey> list_peers();
+	sequence<ChannelDetails> list_channels();
 };
 
 [Error]
@@ -109,6 +110,29 @@ dictionary PaymentInfo {
 	u64? amount_msat;
 	PaymentDirection direction;
 	PaymentStatus status;
+};
+
+dictionary OutPoint {
+    string txid;
+    u16 index;
+};
+
+dictionary ChannelDetails {
+    ChannelId channel_id;
+    PublicKey counterparty;
+    OutPoint? funding_txo;
+    u64? short_channel_id;
+    u64 channel_value_satoshis;
+    u64 balance_msat;
+    u64 outbound_capacity_msat;
+    u64 inbound_capacity_msat;
+    u32? confirmations_required;
+    u32? confirmations;
+    boolean is_outbound;
+    boolean is_channel_ready;
+    boolean is_usable;
+    boolean is_public;
+    u16? cltv_expiry_delta;
 };
 
 [Custom]

--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -51,6 +51,7 @@ interface Node {
 	[Throws=NodeError]
 	Invoice receive_variable_amount_payment([ByRef]string description, u32 expiry_secs);
 	PaymentInfo? payment_info([ByRef]PaymentHash payment_hash);
+	sequence<PublicKey> list_peers();
 };
 
 [Error]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,8 @@ use payment_store::PaymentInfoStorage;
 pub use payment_store::{PaymentDirection, PaymentInfo, PaymentStatus};
 use peer_store::{PeerInfo, PeerInfoStorage};
 use types::{
-	ChainMonitor, ChannelManager, GossipSync, KeysManager, Network, NetworkGraph, OnionMessenger,
-	PeerManager, Scorer,
+	ChainMonitor, ChannelDetails, ChannelManager, GossipSync, KeysManager, Network, NetworkGraph,
+	OnionMessenger, OutPoint, PeerManager, Scorer,
 };
 pub use types::{ChannelId, UserChannelId};
 use wallet::Wallet;
@@ -112,7 +112,7 @@ use logger::{log_error, log_info, FilesystemLogger, Logger};
 use lightning::chain::keysinterface::EntropySource;
 use lightning::chain::{chainmonitor, BestBlock, Confirm, Watch};
 use lightning::ln::channelmanager::{
-	self, ChainParameters, ChannelDetails, ChannelManagerReadArgs, PaymentId, Retry,
+	self, ChainParameters, ChannelManagerReadArgs, PaymentId, Retry,
 };
 use lightning::ln::peer_handler::{IgnoringMessageHandler, MessageHandler};
 use lightning::ln::{PaymentHash, PaymentPreimage, PaymentSecret};
@@ -853,7 +853,7 @@ impl Node {
 
 	/// Retrieve a list of known channels.
 	pub fn list_channels(&self) -> Vec<ChannelDetails> {
-		self.channel_manager.list_channels()
+		self.channel_manager.list_channels().iter().map(|c| c.clone().into()).collect()
 	}
 
 	/// Connect to a node on the peer-to-peer network.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ pub use payment_store::{PaymentDirection, PaymentInfo, PaymentStatus};
 use peer_store::{PeerInfo, PeerInfoStorage};
 use types::{
 	ChainMonitor, ChannelDetails, ChannelManager, GossipSync, KeysManager, Network, NetworkGraph,
-	OnionMessenger, OutPoint, PeerManager, Scorer,
+	OnionMessenger, OutPoint, PeerDetails, PeerManager, Scorer,
 };
 pub use types::{ChannelId, UserChannelId};
 use wallet::Wallet;
@@ -1343,8 +1343,17 @@ impl Node {
 	}
 
 	/// List node's connected peers.
-	pub fn list_peers(&self) -> Vec<PublicKey> {
-		self.peer_manager.get_peer_node_ids().iter().map(|(pubkey, _)| *pubkey).collect::<Vec<_>>()
+	pub fn list_peers(&self) -> Vec<PeerDetails> {
+		let active_connected_peers: Vec<PublicKey> =
+			self.peer_manager.get_peer_node_ids().iter().map(|p| p.0).collect();
+		self.peer_store
+			.list_peers()
+			.iter()
+			.map(|p| PeerDetails {
+				node_id: p.pubkey,
+				is_connected: active_connected_peers.contains(&p.pubkey),
+			})
+			.collect()
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1341,6 +1341,11 @@ impl Node {
 	pub fn payment_info(&self, payment_hash: &PaymentHash) -> Option<PaymentInfo> {
 		self.payment_store.get(payment_hash)
 	}
+
+	/// List node's connected peers.
+	pub fn list_peers(&self) -> Vec<PublicKey> {
+		self.peer_manager.get_peer_node_ids().iter().map(|(pubkey, _)| *pubkey).collect::<Vec<_>>()
+	}
 }
 
 async fn connect_peer_if_necessary(

--- a/src/test/functional_tests.rs
+++ b/src/test/functional_tests.rs
@@ -37,7 +37,10 @@ fn channel_full_cycle() {
 		.connect_open_channel(&node_b.node_id(), &node_b.listening_address().unwrap(), 50000, true)
 		.unwrap();
 
-	assert_eq!(node_a.list_peers(), [node_b.node_id()]);
+	assert_eq!(
+		node_a.list_peers().iter().map(|p| p.node_id).collect::<Vec<_>>(),
+		[node_b.node_id()]
+	);
 
 	let funding_txo = loop {
 		let details = node_a.channel_manager.list_channels();

--- a/src/test/functional_tests.rs
+++ b/src/test/functional_tests.rs
@@ -37,6 +37,8 @@ fn channel_full_cycle() {
 		.connect_open_channel(&node_b.node_id(), &node_b.listening_address().unwrap(), 50000, true)
 		.unwrap();
 
+	assert_eq!(node_a.list_peers(), [node_b.node_id()]);
+
 	let funding_txo = loop {
 		let details = node_a.list_channels();
 

--- a/src/test/functional_tests.rs
+++ b/src/test/functional_tests.rs
@@ -40,7 +40,7 @@ fn channel_full_cycle() {
 	assert_eq!(node_a.list_peers(), [node_b.node_id()]);
 
 	let funding_txo = loop {
-		let details = node_a.list_channels();
+		let details = node_a.channel_manager.list_channels();
 
 		if details.is_empty() || details[0].funding_txo.is_none() {
 			std::thread::sleep(Duration::from_secs(1));

--- a/src/types.rs
+++ b/src/types.rs
@@ -431,3 +431,13 @@ impl From<LdkOutpoint> for OutPoint {
 		OutPoint { txid: value.txid.to_string(), index: value.index }
 	}
 }
+
+/// Details about peers the user is connected to. As returned by [`Node::list_peers`].
+///
+/// [`Node::list_peers`]: [`crate::Node::list_peers`]
+pub struct PeerDetails {
+	/// Our peer's node ID.
+	pub node_id: PublicKey,
+	/// Indicates whether or not the user is currently has an active connection with the peer.
+	pub is_connected: bool,
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,6 +7,8 @@ use crate::UniffiCustomTypeConverter;
 
 use lightning::chain::chainmonitor;
 use lightning::chain::keysinterface::InMemorySigner;
+use lightning::chain::transaction::OutPoint as LdkOutpoint;
+use lightning::ln::channelmanager::ChannelDetails as LdkChannelDetails;
 use lightning::ln::peer_handler::IgnoringMessageHandler;
 use lightning::ln::{PaymentHash, PaymentPreimage, PaymentSecret};
 use lightning::routing::gossip;
@@ -337,5 +339,95 @@ impl UniffiCustomTypeConverter for Network {
 
 	fn from_custom(obj: Self) -> Self::Builtin {
 		obj.0.to_string()
+	}
+}
+
+/// Details about the user's channel as returned by [`Node::list_channels`].
+///
+/// [`Node::list_channels`]: [`crate::Node::list_channels`]
+pub struct ChannelDetails {
+	/// The channel's ID.
+	pub channel_id: ChannelId,
+	/// The `node_id` of our channel's counterparty.
+	pub counterparty: PublicKey,
+	/// Information about the channel's funding transaction output. `None `unless a funding
+	/// transaction has been successfully negotiated with the channel's counterparty.
+	pub funding_txo: Option<OutPoint>,
+	/// Position of the funding transaction on-chain. `None` unless the funding transaction has been
+	/// confirmed and fully opened.
+	pub short_channel_id: Option<u64>,
+	/// The value, in satoshis, of this channel as appears in the funding output.
+	pub channel_value_satoshis: u64,
+	/// Total balance of the channel. It is the amount that will be returned to the user if the
+	/// channel is closed. The value is not exact, due to potential in-flight and fee-rate changes.
+	/// Therefore, exactly this amount is likely irrecoverable on close.
+	pub balance_msat: u64,
+	/// Available outbound capacity for sending HTLCs to the remote peer. The amount does not
+	/// include any pending HTLCs which are not yet resolved (and, thus, whose balance is not
+	/// available for inclusion in new outbound HTLCs). This further does not include any
+	/// pending outgoing HTLCs which are awaiting some other resolution to be sent.
+	pub outbound_capacity_msat: u64,
+	/// Available outbound capacity for sending HTLCs to the remote peer. The amount does not
+	/// include any pending HTLCs which are not yet resolved (and, thus, whose balance is not
+	/// available for inclusion in new inbound HTLCs). This further does not include any
+	/// pending outgoing HTLCs which are awaiting some other resolution to be sent.
+	pub inbound_capacity_msat: u64,
+	/// The number of required confirmations on the funding transactions before the funding is
+	/// considered "locked". The amount is selected by the channel fundee.
+	///
+	/// The value will be `None` for outbound channels until the counterparty accepts the channel.
+	pub confirmations_required: Option<u32>,
+	/// The current number of confirmations on the funding transaction.
+	pub confirmations: Option<u32>,
+	/// Returns `True` if the channel was initiated (and therefore funded) by us.
+	pub is_outbound: bool,
+	/// Returns `True` if the channel is confirmed, both parties have exchanged `channel_ready`
+	/// messages, and the channel is not currently being shut down. Both parties exchange
+	/// `channel_ready` messages upon independently verifying that the required confirmations count
+	/// provided by `confirmations_required` has been reached.
+	pub is_channel_ready: bool,
+	/// Returns `True` if the channel is (a) confirmed and `channel_ready` has been exchanged,
+	/// (b) the peer is connected, and (c) the channel is not currently negotiating shutdown.
+	pub is_usable: bool,
+	/// Returns `True` if this channel is (or will be) publicly-announced
+	pub is_public: bool,
+	/// The difference in the CLTV value between incoming HTLCs and an outbound HTLC forwarded over
+	/// the channel.
+	pub cltv_expiry_delta: Option<u16>,
+}
+
+impl From<LdkChannelDetails> for ChannelDetails {
+	fn from(value: LdkChannelDetails) -> Self {
+		ChannelDetails {
+			channel_id: ChannelId(value.channel_id),
+			counterparty: value.counterparty.node_id,
+			funding_txo: value.funding_txo.and_then(|o| Some(o.into())),
+			short_channel_id: value.short_channel_id,
+			channel_value_satoshis: value.channel_value_satoshis,
+			balance_msat: value.balance_msat,
+			outbound_capacity_msat: value.outbound_capacity_msat,
+			inbound_capacity_msat: value.inbound_capacity_msat,
+			confirmations_required: value.confirmations_required,
+			confirmations: value.confirmations,
+			is_outbound: value.is_outbound,
+			is_channel_ready: value.is_channel_ready,
+			is_usable: value.is_usable,
+			is_public: value.is_public,
+			cltv_expiry_delta: value.config.and_then(|c| Some(c.cltv_expiry_delta)),
+		}
+	}
+}
+
+/// Data structure that references and transaction output.
+pub struct OutPoint {
+	/// The referenced transaction's txid.
+	pub txid: String,
+	/// The index of the referenced output in its transaction's vout.
+	pub index: u16,
+}
+
+impl From<LdkOutpoint> for OutPoint {
+	fn from(value: LdkOutpoint) -> Self {
+		OutPoint { txid: value.txid.to_string(), index: value.index }
 	}
 }


### PR DESCRIPTION
Let me know if we want to expose a shorter list of fields to users/anything in documentation needs tweaking here. I copied/rephrased mostly from `rust-lightning` to be more relevant to an `LdkNode` user.