### PR TITLE
Add Gradle and GitHub Actions tooling to package for Maven Central

### DIFF
--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,0 +1,43 @@
+name: Publish ldk-node-android to Maven Central
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Check out PR branch"
+        uses: actions/checkout@v2
+
+      - name: "Cache"
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: "Set up JDK"
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: "Install Rust Android targets"
+        run: rustup target add x86_64-linux-android aarch64-linux-android armv7-linux-androideabi
+
+      - name: "Build ldk-node-android library"
+        run: |
+          export PATH=$PATH:$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin
+          ./scripts/uniffi_bindgen_generate_kotlin_android.sh
+
+      - name: "Publish to Maven Local and Maven Central"
+        env:
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
+        run: |
+          cd bindings/kotlin/ldk-node-android
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/.github/workflows/publish-jvm.yml
+++ b/.github/workflows/publish-jvm.yml
@@ -1,0 +1,86 @@
+name: Publish ldk-node-jvm to Maven Central
+on: [workflow_dispatch]
+
+jobs:
+  build-jvm-macOS-M1-native-lib:
+    name: "Create M1 and x86_64 JVM native binaries"
+    runs-on: macos-12
+    steps:
+      - name: "Checkout publishing branch"
+        uses: actions/checkout@v2
+
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: Install aarch64 Rust target
+        run: rustup target add aarch64-apple-darwin
+
+      - name: Build ldk-node-jvm library
+        run: |
+          ./scripts/uniffi_bindgen_generate_kotlin.sh
+
+      # build aarch64 + x86_64 native libraries and upload
+      - name: Upload macOS native libraries for reuse in publishing job
+        uses: actions/upload-artifact@v3
+        with:
+          # name: no name is required because we upload the entire directory
+          # the default name "artifact" will be used
+          path: /Users/runner/work/ldk-node/ldk-node/bindings/kotlin/ldk-node-jvm/lib/src/main/resources/
+
+  build-jvm-full-library:
+    name: "Create full ldk-node-jvm library"
+    needs: [build-jvm-macOS-M1-native-lib]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Check out PR branch"
+        uses: actions/checkout@v2
+
+      - name: "Cache"
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ./target
+          key: ${{ runner.os }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+
+      - name: "Set up JDK"
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 11
+
+      - name: "Build ldk-node-jvm library"
+        run: |
+          ./scripts/uniffi_bindgen_generate_kotlin.sh
+
+      - name: Download macOS native libraries from previous job
+        uses: actions/download-artifact@v3
+        id: download
+        with:
+          # download the artifact created in the prior job (named "artifact")
+          name: artifact
+          path: ./bindings/kotlin/ldk-node-jvm/lib/src/main/resources/
+
+      - name: "Publish to Maven Local and Maven Central"
+        env:
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.PGP_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.PGP_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.NEXUS_PASSWORD }}
+        run: |
+          cd bindings/kotlin/ldk-node-jvm
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository

--- a/bindings/kotlin/ldk-node-android/build.gradle.kts
+++ b/bindings/kotlin/ldk-node-android/build.gradle.kts
@@ -14,4 +14,23 @@ plugins {
 // library version is defined in gradle.properties
 val libraryVersion: String by project
 
+// These properties are required here so that the nexus publish-plugin
+// finds a staging profile with the correct group (group is otherwise set as "")
+// and knows whether to publish to a SNAPSHOT repository or not
+// https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
+group = "org.lightningdevkit"
 version = libraryVersion
+
+nexusPublishing {
+    repositories {
+        create("sonatype") {
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+
+            val ossrhUsername: String? by project
+            val ossrhPassword: String? by project
+            username.set(ossrhUsername)
+            password.set(ossrhPassword)
+        }
+    }
+}

--- a/bindings/kotlin/ldk-node-android/gradle.properties
+++ b/bindings/kotlin/ldk-node-android/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx1536m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-libraryVersion=0.1
+libraryVersion=0.0.1-SNAPSHOT

--- a/bindings/kotlin/ldk-node-android/lib/build.gradle.kts
+++ b/bindings/kotlin/ldk-node-android/lib/build.gradle.kts
@@ -60,7 +60,7 @@ afterEvaluate {
     publishing {
         publications {
             create<MavenPublication>("maven") {
-                groupId = "co.jurvis"
+                groupId = "org.lightningdevkit"
                 artifactId = "ldk-node-android"
                 version = libraryVersion
 
@@ -68,7 +68,7 @@ afterEvaluate {
                 pom {
                     name.set("ldk-node-android")
                     description.set(
-                        "Kotlin language bindings for LdkNode, a ready-to-go LDK node implementation"
+                        "LDK Node, a ready-to-go node implementation built using LDK."
                     )
                     url.set("https://lightningdevkit.org")
                     licenses {
@@ -94,9 +94,9 @@ afterEvaluate {
                         }
                     }
                     scm {
-                        connection.set("scm:git:github.com/jurvis/ldk-node.git")
-                        developerConnection.set("scm:git:ssh://github.com/jurvis/ldk-node.git")
-                        url.set("https://github.com/jurvis/ldk-node/tree/main")
+                        connection.set("scm:git:github.com/lightningdevkit/ldk-node.git")
+                        developerConnection.set("scm:git:ssh://github.com/lightningdevkit/ldk-node.git")
+                        url.set("https://github.com/lightningdevkit/ldk-node/tree/main")
                     }
                 }
             }

--- a/bindings/kotlin/ldk-node-android/lib/build.gradle.kts
+++ b/bindings/kotlin/ldk-node-android/lib/build.gradle.kts
@@ -1,9 +1,15 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.*
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
+// library version is defined in gradle.properties
+val libraryVersion: String by project
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android") version "1.6.10"
+
+    id("maven-publish")
+    id("signing")
 }
 
 repositories {
@@ -48,6 +54,62 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
     androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.1")
     androidTestImplementation("org.jetbrains.kotlin:kotlin-test-junit")
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("maven") {
+                groupId = "co.jurvis"
+                artifactId = "ldk-node-android"
+                version = libraryVersion
+
+                from(components["release"])
+                pom {
+                    name.set("ldk-node-android")
+                    description.set(
+                        "Kotlin language bindings for LdkNode, a ready-to-go LDK node implementation"
+                    )
+                    url.set("https://lightningdevkit.org")
+                    licenses {
+                        license {
+                            name.set("APACHE 2.0")
+                            url.set("https://github.com/lightningdevkit/ldk-node/blob/main/LICENSE-APACHE")
+                        }
+                        license {
+                            name.set("MIT")
+                            url.set("https://github.com/lightningdevkit/ldk-node/blob/main/LICENSE-MIT")
+                        }
+                    }
+                    developers {
+                        developer {
+                            id.set("tnull")
+                            name.set("Elias Rohrer")
+                            email.set("tnull@noreply.github.org")
+                        }
+                        developer {
+                            id.set("jurvis")
+                            name.set("Jurvis Tan")
+                            email.set("jurvis@noreply.github.org")
+                        }
+                    }
+                    scm {
+                        connection.set("scm:git:github.com/jurvis/ldk-node.git")
+                        developerConnection.set("scm:git:ssh://github.com/jurvis/ldk-node.git")
+                        url.set("https://github.com/jurvis/ldk-node/tree/main")
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    val signingKeyId: String? by project
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    sign(publishing.publications)
 }
 
 //tasks.named<Test>("test") {

--- a/bindings/kotlin/ldk-node-jvm/build.gradle.kts
+++ b/bindings/kotlin/ldk-node-jvm/build.gradle.kts
@@ -1,0 +1,36 @@
+buildscript {
+    repositories {
+        google()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:7.1.2")
+    }
+}
+
+plugins {
+    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+}
+
+// library version is defined in gradle.properties
+val libraryVersion: String by project
+
+// These properties are required here so that the nexus publish-plugin
+// finds a staging profile with the correct group (group is otherwise set as "")
+// and knows whether to publish to a SNAPSHOT repository or not
+// https://github.com/gradle-nexus/publish-plugin#applying-the-plugin
+group = "org.lightningdevkit"
+version = libraryVersion
+
+nexusPublishing {
+    repositories {
+        create("sonatype") {
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+
+            val ossrhUsername: String? by project
+            val ossrhPassword: String? by project
+            username.set(ossrhUsername)
+            password.set(ossrhPassword)
+        }
+    }
+}

--- a/bindings/kotlin/ldk-node-jvm/gradle.properties
+++ b/bindings/kotlin/ldk-node-jvm/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx1536m
+kotlin.code.style=official
+libraryVersion=0.0.1-SNAPSHOT

--- a/bindings/kotlin/ldk-node-jvm/lib/build.gradle.kts
+++ b/bindings/kotlin/ldk-node-jvm/lib/build.gradle.kts
@@ -58,7 +58,7 @@ afterEvaluate {
     publishing {
         publications {
             create<MavenPublication>("maven") {
-                groupId = "co.jurvis"
+                groupId = "org.lightningdevkit"
                 artifactId = "ldk-node-jvm"
                 version = libraryVersion
 
@@ -66,7 +66,7 @@ afterEvaluate {
                 pom {
                     name.set("ldk-node-jvm")
                     description.set(
-                        "Kotlin language bindings for LdkNode, a ready-to-go LDK node implementation"
+                        "LDK Node, a ready-to-go node implementation built using LDK."
                     )
                     url.set("https://lightningdevkit.org")
                     licenses {
@@ -92,9 +92,9 @@ afterEvaluate {
                         }
                     }
                     scm {
-                        connection.set("scm:git:github.com/jurvis/ldk-node.git")
-                        developerConnection.set("scm:git:ssh://github.com/jurvis/ldk-node.git")
-                        url.set("https://github.com/jurvis/ldk-node/tree/main")
+                        connection.set("scm:git:github.com/lightningdevkit/ldk-node.git")
+                        developerConnection.set("scm:git:ssh://github.com/lightningdevkit/ldk-node.git")
+                        url.set("https://github.com/lightningdevkit/ldk-node/tree/main")
                     }
                 }
             }

--- a/bindings/kotlin/ldk-node-jvm/lib/build.gradle.kts
+++ b/bindings/kotlin/ldk-node-jvm/lib/build.gradle.kts
@@ -1,12 +1,17 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat.*
 import org.gradle.api.tasks.testing.logging.TestLogEvent.*
 
+// library version is defined in gradle.properties
+val libraryVersion: String by project
+
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
     id("org.jetbrains.kotlin.jvm") version "1.7.10"
 
     // Apply the java-library plugin for API and implementation separation.
-    `java-library`
+    id("java-library")
+    id("maven-publish")
+    id("signing")
 }
 
 repositories {
@@ -47,4 +52,60 @@ tasks.named<Test>("test") {
         showStackTraces = true
 		showStandardStreams = true
     }
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("maven") {
+                groupId = "co.jurvis"
+                artifactId = "ldk-node-jvm"
+                version = libraryVersion
+
+                from(components["java"])
+                pom {
+                    name.set("ldk-node-jvm")
+                    description.set(
+                        "Kotlin language bindings for LdkNode, a ready-to-go LDK node implementation"
+                    )
+                    url.set("https://lightningdevkit.org")
+                    licenses {
+                        license {
+                            name.set("APACHE 2.0")
+                            url.set("https://github.com/lightningdevkit/ldk-node/blob/main/LICENSE-APACHE")
+                        }
+                        license {
+                            name.set("MIT")
+                            url.set("https://github.com/lightningdevkit/ldk-node/blob/main/LICENSE-MIT")
+                        }
+                    }
+                    developers {
+                        developer {
+                            id.set("tnull")
+                            name.set("Elias Rohrer")
+                            email.set("tnull@noreply.github.org")
+                        }
+                        developer {
+                            id.set("jurvis")
+                            name.set("Jurvis Tan")
+                            email.set("jurvis@noreply.github.org")
+                        }
+                    }
+                    scm {
+                        connection.set("scm:git:github.com/jurvis/ldk-node.git")
+                        developerConnection.set("scm:git:ssh://github.com/jurvis/ldk-node.git")
+                        url.set("https://github.com/jurvis/ldk-node/tree/main")
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    val signingKeyId: String? by project
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    sign(publishing.publications)
 }

--- a/scripts/uniffi_bindgen_generate_kotlin.sh
+++ b/scripts/uniffi_bindgen_generate_kotlin.sh
@@ -5,6 +5,11 @@ PROJECT_DIR="ldk-node-jvm"
 PACKAGE_DIR="org/lightningdevkit/ldknode"
 UNIFFI_BINDGEN_BIN="cargo run --features=uniffi/cli --bin uniffi-bindgen"
 
+DYNAMIC_LIB_PATH="target/release/libldk_node.dylib"
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  DYNAMIC_LIB_PATH="target/release/libldk_node.so"
+fi
+
 #rustup target add aarch64-apple-darwin
 #cargo build --target aarch64-apple-darwin || exit 1
 cargo build --release || exit 1
@@ -15,4 +20,4 @@ mkdir -p "$BINDINGS_DIR"/"$PROJECT_DIR"/lib/src/main/resources/darwin-aarch64/ |
 
 cp "$TARGET_DIR"/"$PACKAGE_DIR"/ldk_node.kt "$BINDINGS_DIR"/"$PROJECT_DIR"/lib/src/main/kotlin/"$PACKAGE_DIR"/ || exit 1
 #cp ./target/aarch64-apple-darwin/debug/libldk_node.dylib "$BINDINGS_DIR"/"$PROJECT_DIR"/lib/src/main/resources/darwin-aarch64/libldk_node.dylib || exit 1
-cp target/release/libldk_node.dylib "$BINDINGS_DIR"/"$PROJECT_DIR"/lib/src/main/resources/libldk_node.dylib || exit 1
+cp $DYNAMIC_LIB_PATH "$BINDINGS_DIR"/"$PROJECT_DIR"/lib/src/main/resources/libldk_node.dylib || exit 1


### PR DESCRIPTION
Tested and working for...

- [x] [Publishing `ldk-node-android`](https://github.com/jurvis/ldk-node/actions/runs/4569977139)
- [x] [Publishing `ldk-node-jvm`](https://github.com/jurvis/ldk-node/actions/runs/4570462796)

Based on work done by BDK (thanks @thunderbiscuit!)

## Things to do before merge
- [ ] Someone [needs to register for Central](https://central.sonatype.org/publish/#individual-projects-open-source-software-repository-hosting-ossrh)
- [ ] Update Maven publication task def to point to `lightningdevkit/ldk-node` in `ldk-node-android/lib/build.gradle.kts`
- [ ] Generate PGP keys for signing and adding secrets to Github Actions. See: https://github.com/bitcoindevkit/bdk-ffi/issues/270